### PR TITLE
Update Google Play Store link for Boostnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A cross-platform equation solver that solves linear, quadratic,  and cubic equat
 
 [Boostnote Mobile](https://github.com/BoostIO/boostnote-mobile) - Markdown notepad for programmers!
 * [iTunes Store](https://itunes.apple.com/us/app/boostnote/id1273066636?mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=io.boostnote)
+* [Google Play Store](https://play.google.com/store/apps/details?id=io.boostnote) (Temporarily unavailable)
 
 [Gas/Oil Mix Ratio Calculator](https://github.com/filippofilip95/gas-oil-mixture-mobile) - Mobile app which calculate Gasoline/Oil mix ratio for 2 stroke engines.
 * [Google Play Store](https://play.google.com/store/apps/details?id=com.filippofilip.oilratiocalc)


### PR DESCRIPTION
Google Play Store link for Boostnote is currently unavailable, so I added the notice to let user know about it